### PR TITLE
修復cahce login 的問題#74

### DIFF
--- a/src/kuas_api/kuas/cache.py
+++ b/src/kuas_api/kuas/cache.py
@@ -57,11 +57,8 @@ def login(username, password):
     is_login = {}
 
     if red_auth.exists(username):
-        user_redis_cookie = red_auth.get(username)
-
-        login_json = json.loads(user_redis_cookie)
-
-        return login_json
+        user_redis_cookies = red_auth.get(username)
+        return json.loads(user_redis_cookies)
 
     # AP Login
     try:

--- a/src/kuas_api/kuas/cache.py
+++ b/src/kuas_api/kuas/cache.py
@@ -7,7 +7,6 @@ import hashlib
 import requests
 from werkzeug.contrib.cache import SimpleCache
 
-
 import kuas_api.kuas.ap as ap
 import kuas_api.kuas.leave as leave
 import kuas_api.kuas.parse as parse
@@ -34,6 +33,8 @@ s_cache = SimpleCache()
 red = redis.StrictRedis.from_url(url=os.environ['REDIS_URL'], db=2)
 SECRET_KEY = red.get("SECRET_KEY") if red.exists(
     "SECRET_KEY") else str(os.urandom(32))
+# Only use in cache.login , get encoded data from redis.
+# get data from redis should be able use without any decode or encode action.
 red_auth = redis.StrictRedis.from_url(
     url=os.environ['REDIS_URL'], db=2, charset="utf-8", decode_responses=True)
 

--- a/src/kuas_api/kuas/cache.py
+++ b/src/kuas_api/kuas/cache.py
@@ -31,12 +31,14 @@ AP_GUEST_ACCOUNT = "guest"
 AP_GUEST_PASSWORD = "123"
 
 s_cache = SimpleCache()
-red = redis.StrictRedis.from_url(url= os.environ['REDIS_URL'],db=2)
+red = redis.StrictRedis.from_url(url=os.environ['REDIS_URL'], db=2)
 SECRET_KEY = red.get("SECRET_KEY") if red.exists(
     "SECRET_KEY") else str(os.urandom(32))
+red_auth = redis.StrictRedis.from_url(
+    url=os.environ['REDIS_URL'], db=2, charset="utf-8", decode_responses=True)
 
 
-def dump_session_cookies(session,is_login):
+def dump_session_cookies(session, is_login):
     """Dumps cookies to list
     """
 
@@ -47,12 +49,19 @@ def dump_session_cookies(session,is_login):
             'domain': c.domain,
             'value': c.value})
 
-    return {'is_login': is_login, 'cookies':cookies}
+    return {'is_login': is_login, 'cookies': cookies}
 
 
 def login(username, password):
     session = requests.Session()
     is_login = {}
+
+    if red_auth.exists(username):
+        user_redis_cookie = red_auth.get(username)
+
+        login_json = json.loads(user_redis_cookie)
+
+        return login_json
 
     # AP Login
     try:
@@ -72,15 +81,15 @@ def login(username, password):
         is_login["leave"] = leave.login(session, username, password)
     except:
         is_login["leave"] = False
-    if is_login["ap"]: 
-        return dump_session_cookies(session,is_login)
+    if is_login["ap"]:
+        return dump_session_cookies(session, is_login)
     else:
-        return False 
+        return False
 
 
 def ap_query(session, qid=None, args=None,
              username=None, expire=AP_QUERY_EXPIRE):
-    ap_query_key_tag = str(username) + str(args) +  str(SECRET_KEY)
+    ap_query_key_tag = str(username) + str(args) + str(SECRET_KEY)
     ap_query_key = qid + \
         hashlib.sha512(
             bytes(ap_query_key_tag, "utf-8")).hexdigest()
@@ -94,6 +103,7 @@ def ap_query(session, qid=None, args=None,
         ap_query_content = json.loads(red.get(ap_query_key))
 
     return ap_query_content
+
 
 def leave_query(session, year="102", semester="2"):
     return leave.getList(session, year, semester)
@@ -194,27 +204,26 @@ def get_semester_list():
     """
 
     s = requests.Session()
-    ap.login(s,AP_GUEST_ACCOUNT, AP_GUEST_PASSWORD)
+    ap.login(s, AP_GUEST_ACCOUNT, AP_GUEST_PASSWORD)
 
     content = ap_query(s, "ag304_01")
-    if len(content)<3000:
+    if len(content) < 3000:
         return False
     root = etree.HTML(content)
 
     #options = root.xpath("id('yms_yms')/option")
     try:
         options = map(lambda x: {"value": x.values()[0].replace("#", ","),
-                                "selected": 1 if "selected" in x.values() else 0,
-                                "text": x.text},
-                    root.xpath("id('yms_yms')/option")
-                    )
+                                 "selected": 1 if "selected" in x.values() else 0,
+                                 "text": x.text},
+                      root.xpath("id('yms_yms')/option")
+                      )
     except:
         return False
-    
+
     options = list(options)
 
     return options
-
 
 
 if __name__ == "__main__":

--- a/src/kuas_api/modules/stateless_auth.py
+++ b/src/kuas_api/modules/stateless_auth.py
@@ -70,7 +70,7 @@ def generate_auth_token(username, cookies, expiration=600):
     """
     s = Serializer(DIRTY_SECRET_KEY, expires_in=expiration)
 
-    red.set(username, json.dumps(cookies))
+    red.set(username, json.dumps(cookies), ex=600)
 
     return s.dumps({"sid": username})
 


### PR DESCRIPTION
如題
Fixes #74 
cache login 會檢查redis 是否有cookie
cookie 失效時間設定為600秒

----
## wrk test 
![master ](https://user-images.githubusercontent.com/37475932/60358746-8fd51380-9a09-11e9-862d-04609b7ba4f2.png)

![this hotfix](https://user-images.githubusercontent.com/37475932/60358744-8cda2300-9a09-11e9-8981-3c964e4ef506.png)

條件一樣下，有修復與沒修復的差異


---

關於commit的red or red_auth

從redis library上應該拿出bytes 在做編碼的動作，還是拿出資料就已經是編碼好的
我認為沒有太大差別 (後者較優  1000次下 平均差距:0.5~1ms 可以當作沒有效能差距)

這只是一個hotfix 我不認為在這次修正上把以往所有redis的這個問題修正是個好方法，目前要開發
v3，但近期查詢成績過多，v2勢必要先修復了，這PR只是為了解決cache login 的問題，以不引發其他bug為主。



---

每個請求都會call cache.login 這問題
要修太複雜
所以 只在cache.login  好好檢查redis上的cookies
要修復整個邏輯要變動的東西太多，用最少的code修復最主要的問題

