### PR TITLE
修復docker時區異常的問題

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,9 @@ services:
       dockerfile: Dockerfile
     volumes:
     - .:/usr/src/app
-    - /etc/localtime:/etc/localtime:ro
-    - /etc/timezone:/etc/timezone:ro
     environment:
       - REDIS_URL=${REDIS_URL}
+      - "TZ=Asia/Taipei"
     command: [ "gunicorn","-c","gunicorn_cfg.py","web-server:app"]
     networks:
       - redis-net


### PR DESCRIPTION
問題敘述 #76 

在伺服器上(ubuntu 18.04) 透過tzselect去選擇時區
並不會影響到` /etc/localtime` `/etc/timezone`
docker-compose 也會載入到主機上的時區(UTC+0)

docker上的時區設定應該與主機上的脫離

移除
```yaml
volumes:
    - /etc/localtime:/etc/localtime:ro
    - /etc/timezone:/etc/timezone:ro
```
並改為
```yaml
    environment:
      - "TZ=Asia/Taipei"
```
